### PR TITLE
increase interval to 2000

### DIFF
--- a/tinder.js
+++ b/tinder.js
@@ -2,4 +2,4 @@
     function(){
           var elem = document.getElementsByClassName("recsGamepad__button--like");
           elem[0].click()
-          },2500)
+          },2000)

--- a/tinder.js
+++ b/tinder.js
@@ -2,4 +2,4 @@
     function(){
           var elem = document.getElementsByClassName("recsGamepad__button--like");
           elem[0].click()
-          },1000)
+          },2500)


### PR DESCRIPTION
Seems like tinder blocks a user for 12 hours who swipes more than 2000 times in a hour (I have not verified this information). So, may be you want to change the delay to 2000 from current 1000 to be in the safe side. Delay of 2 seconds will at max swipe 1800 times in an hour.